### PR TITLE
Dependency Version Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -212,27 +212,7 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <rule groupId="org.eclipse.microprofile.config" artifactId="microprofile-config-api">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="org.eclipse.microprofile.fault-tolerance" artifactId="microprofile-fault-tolerance-api">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="org.eclipse.microprofile.health" artifactId="microprofile-health-api">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="org.eclipse.microprofile.metrics" artifactId="microprofile-metrics-api">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="org.eclipse.microprofile.opentracing" artifactId="microprofile-opentracing-api">
+        <rule groupId="org.eclipse.microprofile" artifactId="microprofile">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>co.luminositylabs.oss</groupId>
         <artifactId>luminositylabs-oss-parent</artifactId>
-        <version>0.1.18</version>
+        <version>0.1.19</version>
     </parent>
 
     <artifactId>luminositylabs-config</artifactId>
@@ -59,7 +59,7 @@
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.6.0.Final</dependency.arquillian.version>
         <dependency.arquillian-payara-containers.version>2.3.1</dependency.arquillian-payara-containers.version>
-        <dependency.payara.version>5.2020.6</dependency.payara.version>
+        <dependency.payara.version>5.2020.7</dependency.payara.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- updated parent project luminositylabs-oss-parent from v0.1.18 to v0.1.19
- updated payara from v5.2020.6 to v5.2020.7
- updated maven-version-rules.xml to collapsed all microprofile api dependencies into a single microprofile rule