### PR TITLE
Dependency Version Updates

### DIFF
--- a/.bitbucket-pipelines/settings.xml
+++ b/.bitbucket-pipelines/settings.xml
@@ -11,7 +11,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-snapshots</name>
-                    <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
                 </repository>
             </repositories>
         </profile>
@@ -24,7 +24,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-staging</name>
-                    <url>http://oss.sonatype.org/content/groups/staging/</url>
+                    <url>https://oss.sonatype.org/content/groups/staging/</url>
                 </repository>
             </repositories>
         </profile>
@@ -37,7 +37,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-releases</name>
-                    <url>http://oss.sonatype.org/content/groups/public/</url>
+                    <url>https://oss.sonatype.org/content/groups/public/</url>
                 </repository>
             </repositories>
         </profile>

--- a/.github/install-maven.sh
+++ b/.github/install-maven.sh
@@ -3,8 +3,8 @@
 set -euf
 
 MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3/
-MAVEN_VERSION=3.6.3
-MAVEN_SHA=26ad91d751b3a9a53087aefa743f4e16a17741d3915b219cf74112bf87a438c5
+MAVEN_VERSION=3.8.1
+MAVEN_SHA=b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02
 
 sudo apt-get update
 sudo apt-get install -y curl

--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -24,7 +24,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-snapshots</name>
-                    <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
                 </repository>
             </repositories>
         </profile>
@@ -37,7 +37,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-staging</name>
-                    <url>http://oss.sonatype.org/content/groups/staging/</url>
+                    <url>https://oss.sonatype.org/content/groups/staging/</url>
                 </repository>
             </repositories>
         </profile>
@@ -50,7 +50,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-releases</name>
-                    <url>http://oss.sonatype.org/content/groups/public/</url>
+                    <url>https://oss.sonatype.org/content/groups/public/</url>
                 </repository>
             </repositories>
         </profile>

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
         java_version: [8, 11]
-        maven_version: [3.6.3]
+        maven_version: [3.8.1]
         include:
           - os: ubuntu-20.04
             java_version: 11
-            maven_version: 3.6.3
+            maven_version: 3.8.1
             maven_deploy: true
             docker_build: true
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using Zulu ${{ matrix.java_version }}
@@ -84,7 +84,7 @@ jobs:
       env:
         maven_docker_container_image_repo: luminositylabs
         maven_docker_container_image_name: maven
-        maven_docker_container_image_tag: 3.6.3_openjdk-11.0.10_zulu-alpine-11.45.27
+        maven_docker_container_image_tag: 3.8.1_openjdk-11.0.10_zulu-alpine-11.45.27
         CBD: /usr/src/build
         P: luminositylabs-oss
       run: docker container run --rm -i -v "$(pwd)":"${CBD}" -v ${HOME}/.gnupg:/root/.gnupg -v ${P}-${{ env.maven_docker_container_image_tag }}-mvn-repo:/root/.m2 -w "${CBD}" ${{ env.maven_docker_container_image_repo }}/${{ env.maven_docker_container_image_name }}:${{ env.maven_docker_container_image_tag }} mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} dependency:list-repositories dependency:tree help:active-profiles clean install site site:stage

--- a/.travis-ci/install-maven.sh
+++ b/.travis-ci/install-maven.sh
@@ -3,8 +3,8 @@
 set -euf
 
 MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3/
-MAVEN_VERSION=3.6.3
-MAVEN_SHA=26ad91d751b3a9a53087aefa743f4e16a17741d3915b219cf74112bf87a438c5
+MAVEN_VERSION=3.8.1
+MAVEN_SHA=b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02
 
 sudo apt-get update
 sudo apt-get install -y curl

--- a/.travis-ci/settings.xml
+++ b/.travis-ci/settings.xml
@@ -24,7 +24,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-snapshots</name>
-                    <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
                 </repository>
             </repositories>
         </profile>
@@ -37,7 +37,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-staging</name>
-                    <url>http://oss.sonatype.org/content/groups/staging/</url>
+                    <url>https://oss.sonatype.org/content/groups/staging/</url>
                 </repository>
             </repositories>
         </profile>
@@ -50,7 +50,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-releases</name>
-                    <url>http://oss.sonatype.org/content/groups/public/</url>
+                    <url>https://oss.sonatype.org/content/groups/public/</url>
                 </repository>
             </repositories>
         </profile>

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 pipelines:
     default:
         - step:
-            image: luminositylabs/maven:3.6.3_openjdk-11.0.10_zulu-alpine-11.45.27
+            image: luminositylabs/maven:3.8.1_openjdk-11.0.10_zulu-alpine-11.45.27
             script:
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:list-repositories
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:tree

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>co.luminositylabs.oss</groupId>
         <artifactId>luminositylabs-oss-parent</artifactId>
-        <version>0.1.22</version>
+        <version>0.1.23-SNAPSHOT</version>
     </parent>
 
     <artifactId>luminositylabs-config</artifactId>
@@ -58,8 +58,8 @@
     <properties>
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.6.0.Final</dependency.arquillian.version>
-        <dependency.arquillian-payara-containers.version>2.3.3</dependency.arquillian-payara-containers.version>
-        <dependency.payara.version>5.2021.1</dependency.payara.version>
+        <dependency.arquillian-payara-containers.version>2.4.1</dependency.arquillian-payara-containers.version>
+        <dependency.payara.version>5.2021.2</dependency.payara.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- updated parent project luminositylabs-oss-parent from v0.1.22 to v0.1.23-SNAPSHOT
- updated arquillian-payara-containers from v2.3.3 to v2.4.1
- updated payara from v5.2021.1 to v5.2021.2
- updated maven from v3.6.3 to v3.8.1
- updated maven settings.xml files to use https instead of http for repository urls