### PR TITLE
Dependency Version Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -324,7 +324,7 @@
              referenced from arquillian-bom v1.6.0.Final -->
         <rule groupId="ch.qos.logback" artifactId="logback-classic" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">1\.2\.[2-5]</ignoreVersion>
+                <ignoreVersion type="regex">1\.2\.[2-6]</ignoreVersion>
                 <ignoreVersion type="regex">.*-groovyless</ignoreVersion>
             </ignoreVersions>
         </rule>
@@ -421,6 +421,11 @@
             </ignoreVersions>
         </rule>
         <rule groupId="org.codehaus.plexus" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="org.eclipse.sisu" artifactId="org.eclipse.sisu" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>


### PR DESCRIPTION
- added rule to maven-version-rules.xml to ignore org.eclipse.sisu artifacts since maven uses an older version and
  this project does not explicitly depend on them