### PR TITLE
Updates

### DIFF
--- a/.github/install-maven.sh
+++ b/.github/install-maven.sh
@@ -3,8 +3,8 @@
 set -euf
 
 MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3/
-MAVEN_VERSION=3.8.3
-MAVEN_SHA=0f1597d11085b8fe93d84652a18c6deea71ece9fabba45a02cf6600c7758fd5b
+MAVEN_VERSION=3.8.4
+MAVEN_SHA=2cdc9c519427bb20fdc25bef5a9063b790e4abd930e7b14b4e9f4863d6f9f13c
 
 sudo apt-get update
 sudo apt-get install -y curl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         java_version: [8, 11]
-        maven_version: [3.8.3]
+        maven_version: [3.8.4]
         include:
           - os: ubuntu-20.04
             java_version: 11
-            maven_version: 3.8.3
+            maven_version: 3.8.4
             maven_deploy: true
             docker_build: true
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using Zulu ${{ matrix.java_version }}
@@ -87,7 +87,7 @@ jobs:
       env:
         maven_docker_container_image_repo: luminositylabs
         maven_docker_container_image_name: maven
-        maven_docker_container_image_tag: 3.8.3_openjdk-11.0.13_zulu-alpine-11.52.13
+        maven_docker_container_image_tag: 3.8.4_openjdk-11.0.13_zulu-alpine-11.52.13
         CBD: /usr/src/build
         P: luminositylabs-oss
       run: docker container run --rm -i -v "$(pwd)":"${CBD}" -v ${HOME}/.gnupg:/root/.gnupg -v ${P}-${{ env.maven_docker_container_image_tag }}-mvn-repo:/root/.m2 -w "${CBD}" ${{ env.maven_docker_container_image_repo }}/${{ env.maven_docker_container_image_name }}:${{ env.maven_docker_container_image_tag }} mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} dependency:list-repositories dependency:tree help:active-profiles clean install site site:stage

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -4,6 +4,7 @@
     <file url="file://$PROJECT_DIR$" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources-filtered" charset="UTF-8" />
     <file url="PROJECT" charset="UTF-8" />
   </component>
 </project>

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 pipelines:
     default:
         - step:
-            image: luminositylabs/maven:3.8.3_openjdk-11.0.13_zulu-alpine-11.52.13
+            image: luminositylabs/maven:3.8.4_openjdk-11.0.13_zulu-alpine-11.52.13
             script:
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:list-repositories
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:tree

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -317,6 +317,16 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <rule groupId="org.osgi" artifactId="osgi.annotation" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="org.osgi" artifactId="osgi.core" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
 
         <!-- Pin testng version to pre-V7 -->
         <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
@@ -329,7 +339,7 @@
              referenced from arquillian-bom v1.6.0.Final -->
         <rule groupId="ch.qos.logback" artifactId="logback-classic" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">1\.2\.[2-6]</ignoreVersion>
+                <ignoreVersion type="regex">1\.2\.[2-7]</ignoreVersion>
                 <ignoreVersion type="regex">.*-groovyless</ignoreVersion>
             </ignoreVersions>
         </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.6.0.Final</dependency.arquillian.version>
         <dependency.arquillian-payara-containers.version>2.4.5</dependency.arquillian-payara-containers.version>
-        <dependency.payara.version>5.2021.8</dependency.payara.version>
+        <dependency.payara.version>5.2021.9</dependency.payara.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- payara updated from v5.2021.8 to v5.2021.9
- updated bitbucket and github actions from maven 3.8.3 to 3.8.4
- add ignore rules for osgi.annotation and osgi.core to maven-version-rules.xml
- update ignore rules for logback in maven-version-rules.xml