### PR TITLE
Updates

### DIFF
--- a/.github/install-maven.sh
+++ b/.github/install-maven.sh
@@ -3,8 +3,8 @@
 set -euf
 
 MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3/
-MAVEN_VERSION=3.8.4
-MAVEN_SHA=2cdc9c519427bb20fdc25bef5a9063b790e4abd930e7b14b4e9f4863d6f9f13c
+MAVEN_VERSION=3.8.6
+MAVEN_SHA=c7047a48deb626abf26f71ab3643d296db9b1e67f1faa7d988637deac876b5a9
 
 sudo apt-get update
 sudo apt-get install -y curl

--- a/.github/install-zulu11.sh
+++ b/.github/install-zulu11.sh
@@ -4,7 +4,7 @@ set -euf
 
 AZUL_GPG_KEY=0xB1998361219BD9C9
 ZULU_VERSION=11
-ZULU_RELEASE=11.0.14-1
+ZULU_RELEASE=11.0.15-1
 
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${AZUL_GPG_KEY}
 sudo apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'

--- a/.github/install-zulu8.sh
+++ b/.github/install-zulu8.sh
@@ -4,7 +4,7 @@ set -euf
 
 AZUL_GPG_KEY=0xB1998361219BD9C9
 ZULU_VERSION=8
-ZULU_RELEASE=8.0.322-1
+ZULU_RELEASE=8.0.332-1
 
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${AZUL_GPG_KEY}
 sudo apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,13 @@ jobs:
   build-codebase:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         java_version: [8, 11]
-        maven_version: [3.8.4]
+        maven_version: [3.8.6]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             java_version: 11
-            maven_version: 3.8.4
+            maven_version: 3.8.6
             maven_deploy: true
             docker_build: true
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using Zulu ${{ matrix.java_version }}
@@ -87,7 +87,7 @@ jobs:
       env:
         maven_docker_container_image_repo: luminositylabs
         maven_docker_container_image_name: maven
-        maven_docker_container_image_tag: 3.8.4_openjdk-11.0.14_zulu-alpine-11.54.23
+        maven_docker_container_image_tag: 3.8.6_openjdk-11.0.15_zulu-alpine-11.56.19
         CBD: /usr/src/build
         P: luminositylabs-oss
       run: docker container run --rm -i -v "$(pwd)":"${CBD}" -v ${HOME}/.gnupg:/root/.gnupg -v ${P}-${{ env.maven_docker_container_image_tag }}-mvn-repo:/root/.m2 -w "${CBD}" ${{ env.maven_docker_container_image_repo }}/${{ env.maven_docker_container_image_name }}:${{ env.maven_docker_container_image_tag }} mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} dependency:list-repositories dependency:tree help:active-profiles clean install site site:stage

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 pipelines:
     default:
         - step:
-            image: luminositylabs/maven:3.8.4_openjdk-11.0.13_zulu-alpine-11.52.13
+            image: luminositylabs/maven:3.8.5_openjdk-11.0.14.1_zulu-alpine-11.54.25
             script:
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:list-repositories
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:tree

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -333,6 +333,13 @@
             </ignoreVersions>
         </rule>
 
+        <!-- Pin checkstyle version to pre-V10 -->
+        <rule groupId="com.puppycrawl.tools" artifactId="checkstyle" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">10\..*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+
         <!-- Pin testng version to pre-V7 -->
         <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
             <ignoreVersions>
@@ -344,7 +351,7 @@
              referenced from arquillian-bom v1.6.0.Final -->
         <rule groupId="ch.qos.logback" artifactId="logback-classic" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">1\.2\.10</ignoreVersion>
+                <ignoreVersion type="regex">1\.2\.1[0-1]</ignoreVersion>
                 <ignoreVersion type="regex">1\.2\.[0-9]</ignoreVersion>
                 <ignoreVersion type="regex">.*-groovyless</ignoreVersion>
             </ignoreVersions>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>co.luminositylabs.oss</groupId>
         <artifactId>luminositylabs-oss-parent</artifactId>
-        <version>0.2.4</version>
+        <version>0.2.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>luminositylabs-config</artifactId>
@@ -59,7 +59,7 @@
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.6.0.Final</dependency.arquillian.version>
         <dependency.arquillian-payara-containers.version>2.4.6</dependency.arquillian-payara-containers.version>
-        <dependency.payara.version>5.2021.10</dependency.payara.version>
+        <dependency.payara.version>5.2022.2</dependency.payara.version>
         <dependency.payara.security-connectors-api.version>2.3.0</dependency.payara.security-connectors-api.version>
     </properties>
 


### PR DESCRIPTION
- github actions workflow os updated from ubuntu-20.04 to ubuntu-22.04
- CI maven updated from v3.8.5 to v3.8.6
- CI zulu-8 updated from v8.0.322-1 to v8.0.332-1
- CI zulu-11 updated from v11.0.14.1-1 to v11.0.15-1
- luminositylabs-oss-parent updated from v0.2.4 to v0.2.6-SNAPSHOT
- payara updated from v5.2021.10 to v5.2022.2
- update ignore rules for logback in maven-version-rules.xml