### PR TITLE
* Updates

### DIFF
--- a/.github/install-zulu11.sh
+++ b/.github/install-zulu11.sh
@@ -4,7 +4,7 @@ set -euf
 
 AZUL_GPG_KEY=0xB1998361219BD9C9
 ZULU_VERSION=11
-ZULU_RELEASE=11.0.16-1
+ZULU_RELEASE=11.0.17-1
 
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${AZUL_GPG_KEY}
 sudo apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'

--- a/.github/install-zulu8.sh
+++ b/.github/install-zulu8.sh
@@ -4,7 +4,7 @@ set -euf
 
 AZUL_GPG_KEY=0xB1998361219BD9C9
 ZULU_VERSION=8
-ZULU_RELEASE=8.0.345-1
+ZULU_RELEASE=8.0.352-1
 
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${AZUL_GPG_KEY}
 sudo apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
       env:
         maven_docker_container_image_repo: luminositylabs
         maven_docker_container_image_name: maven
-        maven_docker_container_image_tag: 3.8.6_openjdk-11.0.16_zulu-alpine-11.58.15
+        maven_docker_container_image_tag: 3.8.6_openjdk-11.0.17_zulu-11.60.19
         CBD: /usr/src/build
         P: luminositylabs-oss
       run: docker container run --rm -i -v "$(pwd)":"${CBD}" -v ${HOME}/.gnupg:/root/.gnupg -v ${P}-${{ env.maven_docker_container_image_tag }}-mvn-repo:/root/.m2 -w "${CBD}" ${{ env.maven_docker_container_image_repo }}/${{ env.maven_docker_container_image_name }}:${{ env.maven_docker_container_image_tag }} mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} dependency:list-repositories dependency:tree help:active-profiles clean install site site:stage

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -6,6 +6,13 @@
         <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>
     <rules>
+        <!-- Pin payara version to pre-v6 -->
+        <rule groupId="fish.payara.api" artifactId="payara-bom" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">6\..*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+
         <!-- Ignore all versions of all artifacts specified in the payara bom -->
         <rule groupId="com.ibm.jbatch" comparisonMethod="maven">
             <ignoreVersions>
@@ -487,7 +494,7 @@
             </ignoreVersions>
         </rule>
 
-        <!-- Ignore other dependencies with newer versions that are not explicity defined
+        <!-- Ignore other dependencies with newer versions that are not explicitly defined
              as a dependency in this project. -->
         <rule groupId="commons-cli" artifactId="commons-cli" comparisonMethod="maven">
             <ignoreVersions>

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.6.0.Final</dependency.arquillian.version>
         <dependency.arquillian-payara-containers.version>2.4.6</dependency.arquillian-payara-containers.version>
-        <dependency.payara.version>5.2022.2</dependency.payara.version>
-        <dependency.payara.security-connectors-api.version>2.3.0</dependency.payara.security-connectors-api.version>
+        <dependency.payara.version>5.2022.4</dependency.payara.version>
+        <dependency.payara.security-connectors-api.version>2.4.0</dependency.payara.security-connectors-api.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- CI zulu-8 updated from v8.0.345-1 to v8.0.352-1
- CI zulu-11 updated from v11.0.16-1 to v11.0.17-1
- payara updated from v5.2022.2 to v5.2022.4
- payara.security-connectors-api updated from v2.3.0 to v2.4.0
- maven-version-rules.xml updated to exclude payara v6

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>