### PR TITLE
* Updates

### DIFF
--- a/.github/install-zulu17.sh
+++ b/.github/install-zulu17.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euf
+
+AZUL_GPG_KEY=0xB1998361219BD9C9
+ZULU_VERSION=17
+ZULU_RELEASE=17.0.5-1
+
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${AZUL_GPG_KEY}
+sudo apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'
+sudo apt-get update
+sudo apt-get install -y zulu-repo
+sudo apt-get update
+sudo apt-get install -y zulu${ZULU_VERSION}=${ZULU_RELEASE}
+sudo sed -i.orig -e "s/^hl /jre /g" -e "s/^jdkhl /jdk /g" /usr/lib/jvm/.zulu${ZULU_VERSION}-ca-amd64.jinfo
+sudo update-java-alternatives --set zulu${ZULU_VERSION}-ca-amd64
+export ALTERNATIVES_JAVAC=$(realpath /etc/alternatives/javac)
+export JAVA_HOME=${ALTERNATIVES_JAVAC%/bin/javac}
+export PATH=$JAVA_HOME/bin:$PATH
+java -version
+
+set +euf
+

--- a/.github/install-zulu19.sh
+++ b/.github/install-zulu19.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euf
+
+AZUL_GPG_KEY=0xB1998361219BD9C9
+ZULU_VERSION=19
+ZULU_RELEASE=19.0.1-1
+
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${AZUL_GPG_KEY}
+sudo apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'
+sudo apt-get update
+sudo apt-get install -y zulu-repo
+sudo apt-get update
+sudo apt-get install -y zulu${ZULU_VERSION}=${ZULU_RELEASE}
+sudo sed -i.orig -e "s/^hl /jre /g" -e "s/^jdkhl /jdk /g" /usr/lib/jvm/.zulu${ZULU_VERSION}-ca-amd64.jinfo
+sudo update-java-alternatives --set zulu${ZULU_VERSION}-ca-amd64
+export ALTERNATIVES_JAVAC=$(realpath /etc/alternatives/javac)
+export JAVA_HOME=${ALTERNATIVES_JAVAC%/bin/javac}
+export PATH=$JAVA_HOME/bin:$PATH
+java -version
+
+set +euf
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java_version: [8, 11]
+        java_version: [8]
         maven_version: [3.8.6]
         include:
           - os: ubuntu-22.04
-            java_version: 11
+            java_version: 8
             maven_version: 3.8.6
             maven_deploy: true
             docker_build: true
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install GPG and generate test key
       run: .github/install-gpg.sh
@@ -42,7 +42,7 @@ jobs:
       run: .github/install-maven.sh
 
     - name: Setup Maven repository cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: m2repo
       with:
@@ -76,7 +76,7 @@ jobs:
       run: mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} site site:stage
 
     - name: Maven deploy
-      if: ${{ matrix.maven_deploy && (github.ref == 'refs/heads/main') && (github.event_name != 'pull_request')  }}
+      if: ${{ matrix.maven_deploy && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/jdk8') && (github.event_name != 'pull_request')  }}
       env:
         OSSRHU: ${{ secrets.OSSRHU }}
         OSSRHT: ${{ secrets.OSSRHT }}
@@ -87,7 +87,7 @@ jobs:
       env:
         maven_docker_container_image_repo: luminositylabs
         maven_docker_container_image_name: maven
-        maven_docker_container_image_tag: 3.8.6_openjdk-11.0.17_zulu-11.60.19
+        maven_docker_container_image_tag: 3.8.6_openjdk-8u352_zulu-alpine-8.66.0.15
         CBD: /usr/src/build
         P: luminositylabs-oss
       run: docker container run --rm -i -v "$(pwd)":"${CBD}" -v ${HOME}/.gnupg:/root/.gnupg -v ${P}-${{ env.maven_docker_container_image_tag }}-mvn-repo:/root/.m2 -w "${CBD}" ${{ env.maven_docker_container_image_repo }}/${{ env.maven_docker_container_image_name }}:${{ env.maven_docker_container_image_tag }} mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} dependency:list-repositories dependency:tree help:active-profiles clean install site site:stage

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -7,7 +7,22 @@
     </ignoreVersions>
     <rules>
         <!-- Pin payara version to pre-v6 -->
-        <rule groupId="fish.payara.api" artifactId="payara-bom" comparisonMethod="maven">
+        <rule groupId="fish.payara.api" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">6\..*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="fish.payara.distributions" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">6\..*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="fish.payara.extras" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">6\..*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="fish.payara.server.appclient" artifactId="payara-client" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">6\..*</ignoreVersion>
             </ignoreVersions>
@@ -354,15 +369,19 @@
             </ignoreVersions>
         </rule>
 
-        <!-- Ignore various older versions of artifacts that are apparently
-             referenced from arquillian-bom v1.6.0.Final -->
-        <rule groupId="ch.qos.logback" artifactId="logback-classic" comparisonMethod="maven">
+        <!-- Pin/ignore logback versions -->
+        <rule groupId="ch.qos.logback" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">1\.2\.1[0-1]</ignoreVersion>
-                <ignoreVersion type="regex">1\.2\.[0-9]</ignoreVersion>
-                <ignoreVersion type="regex">.*-groovyless</ignoreVersion>
+                <!-- Pin logback version to pre-V1.4 -->
+                <ignoreVersion type="regex">1\.4\..*</ignoreVersion>
+
+                <!-- Ignore various older versions of artifacts that are apparently
+                     referenced from arquillian-bom v1.6.0.Final -->
+                <ignoreVersion type="regex">1\.3\.[0-5]</ignoreVersion>
+                <ignoreVersion type="regex">1\.2\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
+
         <!-- Ignore all versions of dependencies that are not explicitly defined in this project,
               but are apparently imported from arquillian-bom v1.6.0.Final -->
         <rule groupId="com.google.inject" artifactId="guice" comparisonMethod="maven">

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <properties>
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.6.0.Final</dependency.arquillian.version>
-        <dependency.arquillian-payara-containers.version>2.4.6</dependency.arquillian-payara-containers.version>
+        <dependency.arquillian-payara-containers.version>2.5</dependency.arquillian-payara-containers.version>
         <dependency.payara.version>5.2022.4</dependency.payara.version>
         <dependency.payara.security-connectors-api.version>2.4.0</dependency.payara.security-connectors-api.version>
     </properties>


### PR DESCRIPTION
- CI zulu-17/19 added
- github actions workflows updated to use v3 for checkout and cache actions
- github actions main workflow set to only use java 8 for now
- arquillian payara containers updated from v2.4.6 to v2.5
- maven-version-rules.xml updated to exclude payara v6
- modifications to maven-version-rules.xml to ignore logback versions newer than 1.3.x

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>