### PR TITLE
Updates and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        jdk_version: [8.0.352-zulu, 11.0.17-zulu, 17.0.5-zulu, 19.0.1-zulu]
+        jdk_version: [11.0.17-zulu, 17.0.5-zulu, 19.0.1-zulu]
         maven_version: [3.8.6]
         include:
           - os: ubuntu-22.04
-            jdk_version: 8.0.352-zulu
+            jdk_version: 11.0.17-zulu
             maven_version: 3.8.6
             maven_deploy: true
             docker_build: true
@@ -94,7 +94,7 @@ jobs:
       env:
         maven_docker_container_image_repo: luminositylabs
         maven_docker_container_image_name: maven
-        maven_docker_container_image_tag: 3.8.6_openjdk-8u352_zulu-alpine-8.66.0.15
+        maven_docker_container_image_tag: 3.8.6_openjdk-11.0.17_zulu-alpine-11.60.19
         CBD: /usr/src/build
         P: luminositylabs-oss
       run: docker container run --rm -i -v "$(pwd)":"${CBD}" -v ${HOME}/.gnupg:/root/.gnupg -v ${P}-${{ env.maven_docker_container_image_tag }}-mvn-repo:/root/.m2 -w "${CBD}" ${{ env.maven_docker_container_image_repo }}/${{ env.maven_docker_container_image_name }}:${{ env.maven_docker_container_image_tag }} mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} -Djavadoc.path=/usr/bin/javadoc dependency:list-repositories dependency:tree help:active-profiles clean install site site:stage

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -6,30 +6,23 @@
         <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>
     <rules>
-        <!-- Pin payara version to pre-v6 -->
-        <rule groupId="fish.payara.api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">6\..*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="fish.payara.distributions" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">6\..*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="fish.payara.extras" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">6\..*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="fish.payara.server.appclient" artifactId="payara-client" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">6\..*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-
         <!-- Ignore all versions of all artifacts specified in the payara bom -->
-        <rule groupId="com.ibm.jbatch" comparisonMethod="maven">
+        <rule groupId="org.apache.santuario" artifactId="xmlsec" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="org.glassfish.soteria" artifactId="jakarta.security.enterprise" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="org.glassfish.soteria" artifactId="soteria.spi.bean.decorator.weld" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="org.glassfish.web" artifactId="jakarta.servlet.jsp.jstl" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
@@ -54,47 +47,7 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <rule groupId="com.hazelcast" artifactId="hazelcast-kubernetes" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="com.sun.activation" artifactId="jakarta.activation" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
         <rule groupId="com.sun.istack" artifactId="istack-commons-runtime" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="com.sun.mail" artifactId="jakarta.mail" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="com.sun.xml.bind" artifactId="jaxb-osgi" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="io.opentracing" artifactId="opentracing-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="io.opentracing" artifactId="opentracing-util" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.activation" artifactId="jakarta.activation-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.annotation" artifactId="jakarta.annotation-api" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
@@ -114,17 +67,7 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <rule groupId="jakarta.enterprise" artifactId="jakarta.enterprise.cdi-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
         <rule groupId="jakarta.enterprise.concurrent" artifactId="jakarta.enterprise.concurrent-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.faces" artifactId="jakarta.faces-api" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
@@ -134,37 +77,7 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <rule groupId="jakarta.interceptor" artifactId="jakarta.interceptor-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.jms" artifactId="jakarta.jms-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
         <rule groupId="jakarta.json" artifactId="jakarta.json-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.json.bind" artifactId="jakarta.json.bind-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.jws" artifactId="jakarta.jws-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.mail" artifactId="jakarta.mail-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.platform" artifactId="jakarta.jakartaee-api" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
@@ -179,67 +92,7 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <rule groupId="jakarta.resource" artifactId="jakarta.resource-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.security.enterprise" artifactId="jakarta.security.enterprise-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.servlet" artifactId="jakarta.servlet-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.servlet.jsp" artifactId="jakarta.servlet.jsp-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.servlet.jsp.jstl" artifactId="jakarta.servlet.jsp.jstl-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.transaction" artifactId="jakarta.transaction-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
         <rule groupId="jakarta.validation" artifactId="jakarta.validation-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.websocket" artifactId="jakarta.websocket-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.ws.rs" artifactId="jakarta.ws.rs-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.xml.bind" artifactId="jakarta.xml.bind-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="jakarta.xml.ws" artifactId="jakarta.xml.ws-api" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="junit" artifactId="junit" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="org.eclipse" artifactId="yasson" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
@@ -259,52 +112,12 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <rule groupId="org.glassfish" artifactId="jakarta.el" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="org.glassfish" artifactId="jakarta.faces" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="org.glassfish" artifactId="jakarta.json" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="org.glassfish" artifactId="javax.enterprise.concurrent" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="org.glassfish" artifactId="jsonp-jaxrs" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="org.glassfish.grizzly" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
         <rule groupId="org.glassfish.hk2" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
         <rule groupId="org.glassfish.jersey" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="org.glassfish.metro" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="org.glassfish.mq" artifactId="mq-distribution" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
@@ -325,11 +138,6 @@
             </ignoreVersions>
         </rule>
         <rule groupId="org.jsoup" artifactId="jsoup" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <rule groupId="org.osgi" artifactId="org.osgi.dto" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
@@ -355,28 +163,19 @@
             </ignoreVersions>
         </rule>
 
-        <!-- Pin checkstyle version to pre-V10 -->
-        <rule groupId="com.puppycrawl.tools" artifactId="checkstyle" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">10\..*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-
-        <!-- Pin testng version to pre-V7 -->
+        <!-- Pin/ignore testng versions -->
         <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">7\..*</ignoreVersion>
+                <ignoreVersion type="regex">7\.[6-9].*</ignoreVersion>
             </ignoreVersions>
         </rule>
 
         <!-- Pin/ignore logback versions -->
         <rule groupId="ch.qos.logback" comparisonMethod="maven">
             <ignoreVersions>
-                <!-- Pin logback version to pre-V1.4 -->
-                <ignoreVersion type="regex">1\.4\..*</ignoreVersion>
-
                 <!-- Ignore various older versions of artifacts that are apparently
                      referenced from arquillian-bom v1.6.0.Final -->
+                <ignoreVersion type="regex">1\.4\.[0-5]</ignoreVersion>
                 <ignoreVersion type="regex">1\.3\.[0-5]</ignoreVersion>
                 <ignoreVersion type="regex">1\.2\..*</ignoreVersion>
             </ignoreVersions>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>co.luminositylabs.oss</groupId>
         <artifactId>luminositylabs-oss-parent</artifactId>
-        <version>0.2.6-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>luminositylabs-config</artifactId>
@@ -58,9 +58,9 @@
     <properties>
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.7.0.Alpha13</dependency.arquillian.version>
-        <dependency.arquillian-payara-containers.version>2.5</dependency.arquillian-payara-containers.version>
-        <dependency.payara.version>5.2022.5</dependency.payara.version>
-        <dependency.payara.security-connectors-api.version>2.4.0</dependency.payara.security-connectors-api.version>
+        <dependency.arquillian-payara-containers.version>3.0.alpha7</dependency.arquillian-payara-containers.version>
+        <dependency.payara.version>6.2022.2</dependency.payara.version>
+        <dependency.payara.security-connectors-api.version>3.0.alpha6</dependency.payara.security-connectors-api.version>
         <dependency.testng.version>7.5</dependency.testng.version>
     </properties>
 
@@ -113,13 +113,7 @@
             </dependency>
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
-                <artifactId>payara-client-ee7</artifactId>
-                <version>${dependency.arquillian-payara-containers.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.arquillian</groupId>
-                <artifactId>payara-client-ee8</artifactId>
+                <artifactId>payara-client-ee9</artifactId>
                 <version>${dependency.arquillian-payara-containers.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/src/main/java/co/luminositylabs/config/Configuration.java
+++ b/src/main/java/co/luminositylabs/config/Configuration.java
@@ -20,8 +20,8 @@ package co.luminositylabs.config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/test/java/co/luminositylabs/config/ConfigurationTest.java
+++ b/src/test/java/co/luminositylabs/config/ConfigurationTest.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
- update CI to use Java11 as minimum version instead of Java8
- parent project version update from v0.2.6-SNAPSHOT to v0.3.0-SNAPSHOT
- arquillian-payara-containers updated from v2.5 to v3.0.alpha7
- payara updated from v5.2020.5 to v6.2022.2
- payara security-connectors-api updated from v2.4.0 to v3.0.alpha6
- modifications to maven-version-rules.xml to rework ignore rules for Payara6, testng, and logback

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>