### PR TITLE
Updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,18 +11,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        jdk_version: [11.0.19-zulu, 17.0.7-zulu]
+        jdk_version: [11.0.20-zulu, 17.0.8-zulu]
         maven_version: [3.9.3]
         include:
           - os: ubuntu-22.04
-            jdk_version: 11.0.19-zulu
-            zulu_version: 11.64.19
+            jdk_version: 11.0.20-zulu
+            zulu_version: 11.66.15
             maven_version: 3.9.3
             maven_deploy: true
             docker_build: true
             maven_docker_container_image_repo: luminositylabs
             maven_docker_container_image_name: maven
-            maven_docker_container_image_tag: 3.9.3_openjdk-11.0.19_zulu-alpine-11.64.19
+            maven_docker_container_image_tag: 3.9.3_openjdk-11.0.20_zulu-alpine-11.66.15
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using JDK ${{ matrix.jdk_version }}
     runs-on: ${{ matrix.os }}
     env:

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 pipelines:
     default:
         - step:
-            image: luminositylabs/maven:3.9.3_openjdk-11.0.19_zulu-alpine-11.64.19
+            image: luminositylabs/maven:3.9.3_openjdk-11.0.20_zulu-alpine-11.66.15
             script:
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:list-repositories
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:tree

--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -10,6 +10,7 @@
             <property name="randomHttpPort">false</property>
             <property name="autoBindHttp">false</property>
             <property name="debug">false</property>
+            <property name="cmdOptions">-Djdk.util.zip.disableZip64ExtraFieldValidation=true</property>
         </configuration>
     </container>
     <container qualifier="payara-server-embedded">


### PR DESCRIPTION
- updated CI zulu from v11.0.19/v17.0.7 to v11.0.20/v17.0.8
- added cmdOptions property to payara-micro-managed arquillian container in integration tests to provide a workaround for breaking change in latest java releases