### PR TITLE
Updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,17 +12,17 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         jdk_version: [8.0.382-zulu, 11.0.20-zulu]
-        maven_version: [3.9.3]
+        maven_version: [3.9.4]
         include:
           - os: ubuntu-22.04
             jdk_version: 8.0.382-zulu
             zulu_version: 8.72.0.17
-            maven_version: 3.9.3
+            maven_version: 3.9.4
             maven_deploy: true
             docker_build: true
             maven_docker_container_image_repo: luminositylabs
             maven_docker_container_image_name: maven
-            maven_docker_container_image_tag: 3.9.3_openjdk-8u382_zulu-alpine-8.72.0.17
+            maven_docker_container_image_tag: 3.9.4_openjdk-8u382_zulu-alpine-8.72.0.17
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using JDK ${{ matrix.jdk_version }}
     runs-on: ${{ matrix.os }}
     env:

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 pipelines:
     default:
         - step:
-            image: luminositylabs/maven:3.9.3_openjdk-11.0.20_zulu-alpine-11.66.15
+            image: luminositylabs/maven:3.9.4_openjdk-17.0.8_zulu-alpine-17.44.15
             script:
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:list-repositories
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:tree

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -1,7 +1,6 @@
 <ruleset comparisonMethod="maven"
-         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 https://www.mojohaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+         xmlns="https://www.mojohaus.org/VERSIONS/RULE/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://www.mojohaus.org/VERSIONS/RULE/2.1.0 https://www.mojohaus.org/versions/versions-model/xsd/rule-2.1.0.xsd">
     <ignoreVersions>
         <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>
@@ -377,7 +376,7 @@
 
                 <!-- Ignore various older versions of artifacts that are apparently
                      referenced from arquillian-bom v1.6.0.Final -->
-                <ignoreVersion type="regex">1\.3\.[0-8]</ignoreVersion>
+                <ignoreVersion type="regex">1\.3\.[0-9]</ignoreVersion>
                 <ignoreVersion type="regex">1\.2\..*</ignoreVersion>
             </ignoreVersions>
         </rule>


### PR DESCRIPTION
- updated CI maven from v3.9.3 to v3.9.4
- maven-version-rules.xml config updated from v2.0.0 to v2.1.0
- maven-version-rules.xml logback versions exclusions updated for v1.3.9/v1.4.9



(cherry picked from commit e708cd5b08184f7056636b696fb6960948681cd3)