### PR TITLE
main updates/fixes

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -243,6 +243,11 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <rule groupId="org.codehaus.woodstox" artifactId="stax2-api" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
         <rule groupId="org.eclipse" artifactId="yasson" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,12 @@
                 <arquillian.launch>payara-micro-managed</arquillian.launch>
             </properties>
             <dependencies>
+                <!-- Declaring slf4j dependency is required here to override the slf4j classes that seem to be shaded
+                     into payara which breaks logging functionality -->
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </dependency>
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-micro-managed</artifactId>
@@ -223,6 +229,12 @@
                 <arquillian.launch>payara-server-embedded</arquillian.launch>
             </properties>
             <dependencies>
+                <!-- Declaring slf4j dependency is required here to override the slf4j classes that seem to be shaded
+                     into payara which breaks logging functionality -->
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </dependency>
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-server-embedded</artifactId>

--- a/src/main/java/co/luminositylabs/config/Configuration.java
+++ b/src/main/java/co/luminositylabs/config/Configuration.java
@@ -17,6 +17,7 @@
 package co.luminositylabs.config;
 
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +43,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  *
  * @author Phillip Ross
  */
+@SuppressFBWarnings({"PI_DO_NOT_REUSE_PUBLIC_IDENTIFIERS_CLASS_NAMES"})
 @ApplicationScoped
 public class Configuration implements Serializable {
 


### PR DESCRIPTION
* - maven-version-rules.xml additions for stax2-api

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>

* - add slf4j dependency before payara and arquillian containers to override the slf4j classes included in payara

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>

* - added @SuppressFBWarning to Configuration class to suppress spotbugs "PI: Do not reuse public identifiers from JSL as class name"

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>

---------

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>
(cherry picked from commit 9613618971fcbafc5cd64150d60ad83249e13d0a)