### PR TITLE
Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -186,6 +186,11 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <rule groupId="org.glassfish.grizzly" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
         <rule groupId="org.glassfish.hk2" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.arquillian.version>1.7.1.Final</dependency.arquillian.version>
+        <dependency.arquillian.version>1.7.2.Final</dependency.arquillian.version>
         <dependency.arquillian-payara-containers.version>3.0.alpha8</dependency.arquillian-payara-containers.version>
         <dependency.payara.version>6.2023.10</dependency.payara.version>
         <dependency.payara.security-connectors-api.version>3.0.alpha6</dependency.payara.security-connectors-api.version>


### PR DESCRIPTION
- arquillian updated from v1.7.1.Final to v1.7.2.Final
- maven-version-rules.xml ignore rule additions for org.glassfish.grizzly