### PR TITLE
Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -415,7 +415,22 @@
 
         <!-- Ignore other dependencies with newer versions that are not explicitly defined
              as a dependency in this project. -->
+        <rule groupId="com.google.guava" artifactId="failureaccess" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="com.google.guava" artifactId="guava" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
         <rule groupId="commons-cli" artifactId="commons-cli" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="commons-io" artifactId="commons-io" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>co.luminositylabs.oss</groupId>
         <artifactId>luminositylabs-oss-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>luminositylabs-config</artifactId>
@@ -57,9 +57,9 @@
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.arquillian.version>1.7.2.Final</dependency.arquillian.version>
+        <dependency.arquillian.version>1.8.0.Final</dependency.arquillian.version>
         <dependency.arquillian-payara-containers.version>3.0.alpha8</dependency.arquillian-payara-containers.version>
-        <dependency.payara.version>6.2023.10</dependency.payara.version>
+        <dependency.payara.version>6.2023.11</dependency.payara.version>
         <dependency.payara.security-connectors-api.version>3.0.alpha6</dependency.payara.security-connectors-api.version>
 
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -10,6 +10,7 @@
         <appender-ref ref="STDOUT" />
     </root>
 
+    <logger name="org.eclipse.aether" level="ERROR"/>
     <logger name="org.hibernate.validator" level="ERROR"/>
     <logger name="org.jboss.logging" level="ERROR"/>
     <logger name="org.jboss.weld" level="ERROR"/>


### PR DESCRIPTION
- parent project luminositylabs-oss-parent updated from v0.3.0-SNAPSHOT to v0.3.1-SNAPSHOT
- arquillian updated from v1.7.2.Final to v1.8.0.Final
- payara updated from v6.2023.10 to v6.2023.11
- maven-version-rules.xml ignore rule additions for guava and commons-io
- lowered org.eclipse.aether logger level from DEBUG to ERROR