### PR TITLE
cleanup and pruning

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -272,16 +272,6 @@
             </ignoreVersions>
         </rule>
 
-        <!-- Pin/ignore logback versions -->
-        <rule groupId="ch.qos.logback" comparisonMethod="maven">
-            <ignoreVersions>
-                <!-- Ignore various older versions of artifacts that are apparently referenced from arquillian-bom -->
-                <ignoreVersion type="regex">1\.4\.([0-9]|1[0-1])</ignoreVersion>
-                <ignoreVersion type="regex">1\.3\.([0-9]|1[0-1])</ignoreVersion>
-                <ignoreVersion type="regex">1\.2\..*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-
         <!-- Ignore all versions of dependencies that are not explicitly defined in this project, but are apparently
              imported from arquillian-bom -->
         <rule groupId="com.google.inject" artifactId="guice" comparisonMethod="maven">
@@ -431,13 +421,6 @@
             </ignoreVersions>
         </rule>
         <rule groupId="commons-io" artifactId="commons-io" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-
-        <!-- Ignore shrinkwrap-resolver versions newer than what is defined by arquillian dependencies -->
-        <rule groupId="org.jboss.shrinkwrap.resolver" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${dependency.logback.version}</version>
+            </dependency>
             <!-- The arquillian-bom dependency imports slf4j-api and slfj-simple which may be defined with older
                  versions and require overriding to get the latest versions. -->
             <dependency>
@@ -84,63 +89,6 @@
                 <version>${dependency.payara.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <!-- The payara-bom artifact may declare transitive dependencies for artifacts in the fish.payara.arquillian
-                 artifact group with versions that are not the latest.  Declare the individual artifacts explicitly to
-                 prevent the versions plugin from reporting the artifacts not being the latest versions -->
-            <dependency>
-                <groupId>fish.payara.arquillian</groupId>
-                <artifactId>arquillian-payara-micro-managed</artifactId>
-                <version>${dependency.arquillian-payara-containers.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.arquillian</groupId>
-                <artifactId>arquillian-payara-server-embedded</artifactId>
-                <version>${dependency.arquillian-payara-containers.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.arquillian</groupId>
-                <artifactId>arquillian-payara-server-managed</artifactId>
-                <version>${dependency.arquillian-payara-containers.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.arquillian</groupId>
-                <artifactId>arquillian-payara-server-remote</artifactId>
-                <version>${dependency.arquillian-payara-containers.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.arquillian</groupId>
-                <artifactId>payara-client-ee9</artifactId>
-                <version>${dependency.arquillian-payara-containers.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.arquillian</groupId>
-                <artifactId>payara-micro-deployer</artifactId>
-                <version>${dependency.arquillian-payara-containers.version}</version>
-                <scope>test</scope>
-                <type>war</type>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.arquillian</groupId>
-                <artifactId>payara-micro-remote</artifactId>
-                <version>${dependency.arquillian-payara-containers.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <!-- The Payara security connectors are not separately versioned. -->
-            <dependency>
-                <groupId>fish.payara.security.connectors</groupId>
-                <artifactId>openid-standalone</artifactId>
-                <version>${dependency.payara.security-connectors-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.security.connectors</groupId>
-                <artifactId>security-connectors-api</artifactId>
-                <version>${dependency.payara.security-connectors-api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -200,15 +148,10 @@
                 <arquillian.launch>payara-micro-managed</arquillian.launch>
             </properties>
             <dependencies>
-                <!-- Declaring slf4j dependency is required here to override the slf4j classes that seem to be shaded
-                     into payara which breaks logging functionality -->
-                <dependency>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </dependency>
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-micro-managed</artifactId>
+                    <version>${dependency.arquillian-payara-containers.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
@@ -233,6 +176,7 @@
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-server-embedded</artifactId>
+                    <version>${dependency.arquillian-payara-containers.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
- add logback-classic dependency to dependency management to remove version-maven-plugin reporting older logback-classic versions
- removed payara arquillian container dependencies from main dependency management section and added version elements to the container-specific maven profile sections for the corresponding arquillian container dependency
- removed dependencies for payara security connectors as the payara-bom appears to declare the latest connector versions
- remove unnecessary slf4j-api dependency declaration from payara-micro maven profile
- updated maven-version-rules.xml to remove ignore rules for logback and shrinkwrap-resolver