### PR TITLE
cleanup and pruning

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -383,12 +383,6 @@
             <ignoreVersions>
                 <!-- Pin logback version to pre-V1.4 -->
                 <ignoreVersion type="regex">1\.4\..*</ignoreVersion>
-
-                <!-- Ignore various older versions of artifacts that are apparently
-                     referenced from arquillian-bom v1.6.0.Final -->
-                <ignoreVersion type="regex">1\.4\.([0-9]|1[0-1])</ignoreVersion>
-                <ignoreVersion type="regex">1\.3\.([0-9]|1[0-1])</ignoreVersion>
-                <ignoreVersion type="regex">1\.2\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
 
@@ -546,11 +540,5 @@
             </ignoreVersions>
         </rule>
 
-        <!-- Ignore shrinkwrap-resolver versions newer than what is defined by arquillian dependencies -->
-        <rule groupId="org.jboss.shrinkwrap.resolver" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
     </rules>
 </ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${dependency.logback.version}</version>
+            </dependency>
             <!-- The arquillian-bom dependency imports slf4j-api and slfj-simple which may be defined with older
                  versions and require overriding to get the latest versions. -->
             <dependency>
@@ -205,12 +210,6 @@
                 <arquillian.launch>payara-micro-managed</arquillian.launch>
             </properties>
             <dependencies>
-                <!-- Declaring slf4j dependency is required here to override the slf4j classes that seem to be shaded
-                     into payara which breaks logging functionality -->
-                <dependency>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </dependency>
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-micro-managed</artifactId>


### PR DESCRIPTION
- add logback-classic dependency to dependency management to remove version-maven-plugin reporting older logback-classic versions
- remove unnecessary slf4j-api dependency declaration from payara-micro maven profile
- updated maven-version-rules.xml to remove ignore rules for logback and shrinkwrap-resolver