### PR TITLE
Updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,18 +11,26 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        jdk_version: [8.0.382-zulu, 11.0.20-zulu]
-        maven_version: [3.9.5]
+        jdk_version: [8.0.392-zulu, 11.0.21-zulu, 17.0.9-zulu]
+        maven_version: [3.9.6]
+        payara_server_embedded_profile_name: [payara-server-embedded, payara-server-embedded-no-jpms]
         include:
           - os: ubuntu-22.04
-            jdk_version: 8.0.382-zulu
-            zulu_version: 8.72.0.17
-            maven_version: 3.9.5
+            jdk_version: 8.0.392-zulu
+            zulu_version: 8.74.0.17
+            maven_version: 3.9.6
             maven_deploy: true
             docker_build: true
             maven_docker_container_image_repo: luminositylabs
             maven_docker_container_image_name: maven
-            maven_docker_container_image_tag: 3.9.5_openjdk-8u382_zulu-alpine-8.72.0.17
+            maven_docker_container_image_tag: 3.9.6_openjdk-8u392_zulu-alpine-8.74.0.17
+        exclude:
+          - jdk_version: 8.0.392-zulu
+            payara_server_embedded_profile_name: payara-server-embedded
+          - jdk_version: 11.0.21-zulu
+            payara_server_embedded_profile_name: payara-server-embedded-no-jpms
+          - jdk_version: 17.0.9-zulu
+            payara_server_embedded_profile_name: payara-server-embedded-no-jpms
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using JDK ${{ matrix.jdk_version }}
     runs-on: ${{ matrix.os }}
     env:
@@ -81,7 +89,7 @@ jobs:
       run: mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} clean install
 
     - name: Maven verify with payara embedded profile
-      run: mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }},payara-server-embedded ${{ env.MAVEN_PROPS }} verify
+      run: mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }},${{ matrix.payara_server_embedded_profile_name }} ${{ env.MAVEN_PROPS }} verify
 
     - name: Maven generate site
       run: mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} site site:stage

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,65 @@
+# Luminosity Labs Configuration Module
+
+## Notes
+
+### Integration Tests
+
+The integration tests for this module are run by the maven failsafe plugin.  This plugin includes a configuration
+ option name "argLine" which allows the specification of JVM arguments for the test runner.  Various arguments are
+ needed for the integration tests to run successfully due to a combination of Payara5 and its included components
+ support (or lack thereof) for the Java Platform Module System (JMPS) in Java9 and above.
+
+#### Payara5
+
+When the maven-failsafe-plugin runs the integration tests in Payara5 without the required JVM arguments, the
+ bootstrapping of the Payara runtime by arquillian fails and the integration tests fail to run successfully.  The
+ following notes attempt to document the details on which JVM arguments are necessary and which are not.
+
+By default, the logging may not be verbose enough to show the warnings/errors containing hints as to the reasons for the
+ failures.  In order to increase the verbosity of the logging, the <java.util.logging.config.file> element can be
+ commented out in the failsafe plugin configuration system properties section, causing logging to be output to the
+ console.
+
+Two separate sections of notes are provided to explain the details when the arquillian test are run in Payara5 embedded
+ edition versus when they are run in Payara5 micro edition.
+
+##### Payara5 Embedded
+
+Payara5 incorporates Hazelcast which requires specific JVM parameters to work property in a JPMS (Java9+) environment.
+ The following warning message is displayed in the logging output when the maven failsafe plugin runs the integration
+ tests by arquillian fails to deploy the application due to Hazelcast failures:
+```
+WARNING: Hazelcast is starting in a Java modular environment (Java 9 and newer) but without proper access to required Java packages. Use additional Java arguments to provide Hazelcast access to Java internal API. The internal API access is used to get the best performance results. Arguments to be used:
+ --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+```
+
+Despite the warning message listing a set of JVM parameters as arguments, not all of these are needed, probably due to
+ either the integration tests not triggering specific functionality in Hazelcast, or the Payara5 container already
+ including the parameters.  The following is the list of JVM parameters specified in the warning message that were
+ found to NOT be necessary to include in the maven failsafe argLine configuration property:
+* --add-modules java.se
+* --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+* --add-opens java.base/java.nio=ALL-UNNAMED
+* --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+* --add-opens java.management/sun.management=ALL-UNNAMED
+* --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+
+The JVM parameter(s) from the Hazelcast warning message that ARE necessary:
+* --add-opens java.base/java.lang=ALL-UNNAMED
+
+Outside of the JVM parameters specified in the Hazelcast warning message, other JVM parameters were found to be
+ necessary for the integration tests to run successfully.  These required JVM parameters where identified by inspecting
+ the logging output of Payara5 during the arquillian bootstrapping/deployment, and consist of the following JVM
+ parameters:
+* --add-opens=java.base/sun.net.www=ALL-UNNAMED
+* --add-opens=java.base/sun.security.util=ALL-UNNAMED
+
+Even when the integration tests succeed, inspecting the logging output of Payara5 revealed warnings, errors, and
+ exception messages that indicated JPMS related issues that can be mitigated with the following additional JVM
+ parameters:
+* --add-opens=java.base/java.net=ALL-UNNAMED
+* --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED
+* --add-opens=java.naming/javax.naming.spi=ALL-UNNAMED
+
+
+ 

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 pipelines:
     default:
         - step:
-            image: luminositylabs/maven:3.9.5_openjdk-17.0.8_zulu-alpine-17.44.15
+            image: luminositylabs/maven:3.9.6_openjdk-8u392_zulu-alpine-8.74.0.17
             script:
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:list-repositories
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:tree

--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,14 @@
         <dependency.arquillian-payara-containers.version>2.5</dependency.arquillian-payara-containers.version>
         <dependency.payara.version>5.2022.5</dependency.payara.version>
         <dependency.payara.security-connectors-api.version>2.4.0</dependency.payara.security-connectors-api.version>
-        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- Some dependency (probably one of the BOMs) in the project has a reference to an older version the
+                 logback-classic artifact, which causes the maven-versions-plugin to report on the outdated version.
+                 This has no bearing on maven's resolution of the dependencies, but the following dependency is declared
+                 explicitly to force the plugin to NOT pay attention to the older version. -->
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
@@ -245,6 +248,17 @@
                     <scope>test</scope>
                 </dependency>
             </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens java.base/java.lang=ALL-UNNAMED  --add-opens=java.base/sun.net.www=ALL-UNNAMED --add-opens=java.base/sun.security.util=ALL-UNNAMED   --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -260,5 +260,29 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>payara-server-embedded-no-jpms</id>
+            <properties>
+                <arquillian.launch>payara-server-embedded</arquillian.launch>
+            </properties>
+            <dependencies>
+                <!-- Declaring slf4j dependency is required here to override the slf4j classes that seem to be shaded
+                     into payara which breaks logging functionality -->
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-server-embedded</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>fish.payara.extras</groupId>
+                    <artifactId>payara-embedded-all</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
- removed explicit pinning of jacoco-maven-plugin to v0.8.8 as it seems using latest version is working
- Added maven-failsafe-plugin to a build section in the payara-server-embedded maven profile which defines an argLine providing JVM parameters necessary for Payara5+Hazelcast for running integration tests
- Added a NOTES.md file with details on integration tests and the necessary JVM arguments for integration tests