### PR TITLE
Dependency Cleanup

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -372,18 +372,18 @@
             </ignoreVersions>
         </rule>
 
-        <!-- Pin testng version to pre-V7 -->
+        <!-- Pin testng version to 7.5.x (v7.6+ requires Java11) -->
         <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">7\..*</ignoreVersion>
+                <ignoreVersion type="regex">7\.[6-9]\..*</ignoreVersion>
+                <ignoreVersion type="regex">7\.10\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
 
-        <!-- Pin/ignore logback versions -->
+        <!-- Pin logback version to v1.3.x (v1.4.0+ requires Java11) -->
         <rule groupId="ch.qos.logback" comparisonMethod="maven">
             <ignoreVersions>
-                <!-- Pin logback version to pre-V1.4 -->
-                <ignoreVersion type="regex">1\.[4-5]\..*</ignoreVersion>
+                <ignoreVersion type="regex">1\.[4-9]\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,15 +65,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Some dependency (probably one of the BOMs) in the project has a reference to an older version the
-                 logback-classic artifact, which causes the maven-versions-plugin to report on the outdated version.
-                 This has no bearing on maven's resolution of the dependencies, but the following dependency is declared
-                 explicitly to force the plugin to NOT pay attention to the older version. -->
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>${dependency.logback.version}</version>
-            </dependency>
             <!-- The arquillian-bom dependency imports slf4j-api and slfj-simple which may be defined with older
                  versions and require overriding to get the latest versions. -->
             <dependency>


### PR DESCRIPTION
- remove logback-classic from dependencies and inherit from parent project (oldeer issues have been fixed)
- update logback and testng ignore rules in maven-version-rules.xml