### PR TITLE
version scheme updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,18 +11,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        jdk_version: [17.0.10-zulu, 21.0.2-zulu]
+        jdk_version: [21.0.2-zulu]
         maven_version: [3.9.6]
         include:
           - os: ubuntu-22.04
-            jdk_version: 17.0.10-zulu
-            zulu_version: 17.48.15
+            jdk_version: 21.0.2-zulu
+            zulu_version: 21.32.17
             maven_version: 3.9.6
             maven_deploy: true
             docker_build: true
             maven_docker_container_image_repo: luminositylabs
             maven_docker_container_image_name: maven
-            maven_docker_container_image_tag: 3.9.6_openjdk-17.0.10_zulu-alpine-17.48.15
+            maven_docker_container_image_tag: 3.9.6_openjdk-21.0.2_zulu-alpine-21.32.17
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using JDK ${{ matrix.jdk_version }}
     runs-on: ${{ matrix.os }}
     env:

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 pipelines:
     default:
         - step:
-            image: luminositylabs/maven:3.9.6_openjdk-11.0.22_zulu-alpine-11.70.15
+            image: luminositylabs/maven:3.9.6_openjdk-21.0.2_zulu-alpine-21.32.17
             script:
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:list-repositories
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:tree

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <artifactId>luminositylabs-config</artifactId>
-    <version>0.17.0.71-SNAPSHOT</version>
+    <version>0.21.0.71-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>luminositylabs-config</name>


### PR DESCRIPTION
- advance project to version 0.21.0.71-SNAPSHOT
- parent project luminositylabs-oss-parent updated from v0.4.1-SNAPSHOT to v0.5.1-SNAPSHOT
- remove zulu-17 from GHA main workflow and set to deploy for zulu-21