### PR TITLE
Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -301,6 +301,13 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <!-- Ignore artifacts declared in the payara-bom which have newer versions.  This works around a complex issue
+             with payara arquillian containers erroneously showing up with outdated transient dependency versions. -->
+        <rule groupId="fish.payara.arquillian" artifactId="payara-micro-deployer" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
 
         <!-- Ignore all versions of dependencies that are not explicitly defined in this project, but are apparently
              imported from arquillian-bom -->

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.8.0.Final</dependency.arquillian.version>
         <dependency.arquillian-payara-containers.version>3.0</dependency.arquillian-payara-containers.version>
-        <dependency.payara.version>6.2024.4</dependency.payara.version>
+        <dependency.payara.version>6.2024.5</dependency.payara.version>
     </properties>
 
     <dependencyManagement>
@@ -72,6 +72,38 @@
                 <version>${dependency.arquillian.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <!-- The payara arquillian dependencies defined in payara-bom are older so explicitly defined the
+                 newer versions here to override the payara-bom declarations -->
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>arquillian-payara-micro-managed</artifactId>
+                <version>${dependency.arquillian-payara-containers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>arquillian-payara-server-embedded</artifactId>
+                <version>${dependency.arquillian-payara-containers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>arquillian-payara-server-managed</artifactId>
+                <version>${dependency.arquillian-payara-containers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>arquillian-payara-server-remote</artifactId>
+                <version>${dependency.arquillian-payara-containers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>payara-client-ee9</artifactId>
+                <version>${dependency.arquillian-payara-containers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>payara-micro-deployer</artifactId>
+                <version>${dependency.arquillian-payara-containers.version}</version>
             </dependency>
             <!-- The payara-bom dependency imports fish.payara.arquillian artifacts which may be defined with older
                  versions and require overriding to get the latest versions. -->
@@ -145,7 +177,6 @@
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-micro-managed</artifactId>
-                    <version>${dependency.arquillian-payara-containers.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
@@ -172,7 +203,6 @@
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-server-embedded</artifactId>
-                    <version>${dependency.arquillian-payara-containers.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
- payara updated from v6.2024.4 to 6.2024.5
- declared explicit dependencies for payara arquillian containers to work around erroneous version update reports
- updated maven-version-rules.xml to include new ignore rules for fish.payara.arquillian:payara-micro-deployer artifact