### PR TITLE
Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -156,6 +156,11 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <rule groupId="jakarta.servlet.jsp.jstl" artifactId="jakarta.servlet.jsp.jstl-api" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
         <rule groupId="jakarta.validation" artifactId="jakarta.validation-api" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.9.1.Final</dependency.arquillian.version>
         <dependency.arquillian-payara-containers.version>3.1</dependency.arquillian-payara-containers.version>
-        <dependency.payara.version>6.2024.7</dependency.payara.version>
+        <dependency.payara.version>6.2024.8</dependency.payara.version>
         <dependency.shrinkwrap-resolver.version>3.3.0</dependency.shrinkwrap-resolver.version>
     </properties>
 


### PR DESCRIPTION
- payara updated from v6.2024.7 to v6.2024.8
- added ignore rule for jakarta.servlet.jsp.jstl-api to maven-version-rules.xml