### PR TITLE
Updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,17 +12,17 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         jdk_version: [21.0.4-zulu]
-        maven_version: [3.9.8]
+        maven_version: [3.9.9]
         include:
           - os: ubuntu-24.04
             jdk_version: 21.0.4-zulu
             zulu_version: 21.34.19
-            maven_version: 3.9.8
+            maven_version: 3.9.9
             maven_deploy: true
             docker_build: true
             maven_docker_container_image_repo: luminositylabs
             maven_docker_container_image_name: maven
-            maven_docker_container_image_tag: 3.9.8_openjdk-21.0.4_zulu-alpine-21.36.17
+            maven_docker_container_image_tag: 3.9.9_openjdk-21.0.4_zulu-alpine-21.36.17
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using JDK ${{ matrix.jdk_version }}
     runs-on: ${{ matrix.os }}
     env:

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 pipelines:
     default:
         - step:
-            image: luminositylabs/maven:3.9.8_openjdk-21.0.4_zulu-alpine-21.36.17
+            image: luminositylabs/maven:3.9.9_openjdk-21.0.4_zulu-alpine-21.36.17
             script:
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:list-repositories
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:tree

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -211,6 +211,11 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <rule groupId="org.glassfish.soteria" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
         <rule groupId="org.glassfish.tyrus" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>


### PR DESCRIPTION
- updated CI maven from v3.9.8 to v3.9.9
- added ignore rule for org.glassfish.soteria to maven-version-rules.xml