### PR TITLE
Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -231,7 +231,12 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <rule groupId="org.yaml" comparisonMethod="snakeyaml">
+        <rule groupId="org.ow2.asm" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="org.yaml" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.9.1.Final</dependency.arquillian.version>
         <dependency.arquillian-payara-containers.version>3.1</dependency.arquillian-payara-containers.version>
-        <dependency.payara.version>6.2024.9</dependency.payara.version>
+        <dependency.payara.version>6.2024.10</dependency.payara.version>
         <dependency.shrinkwrap-resolver.version>3.3.1</dependency.shrinkwrap-resolver.version>
         <dependency.maven-shared-utils.version>3.4.2</dependency.maven-shared-utils.version>
     </properties>
@@ -81,6 +81,12 @@
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
                 <artifactId>arquillian-payara-micro-managed</artifactId>
+                <version>${dependency.arquillian-payara-containers.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>fish.payara.arquillian</groupId>
+                <artifactId>arquillian-payara-micro-remote</artifactId>
                 <version>${dependency.arquillian-payara-containers.version}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
- updated payara from v6.2024.9 to v6.2024.10
- added explicit dependency declaration for arquillian-payara-micro-remote in dependency management
- updated maven-version-rules.xml to add org.ow2.asm ignore rule and fix erroneous comparisonMethod values