### PR TITLE
Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -331,10 +331,22 @@
             </ignoreVersions>
         </rule>
 
-        <!-- Pin checkstyle version to pre-V10 -->
+        <!-- Pin checkstyle version to pre-v10 (v10 requires Java11) -->
         <rule groupId="com.puppycrawl.tools" artifactId="checkstyle" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">10\..*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+
+        <!-- Pin spotbugs version to pre-v4.9.0 (v4.9.0 requires Java11) -->
+        <rule groupId="com.github.spotbugs" artifactId="spotbugs" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">4\.9\..*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="com.github.spotbugs" artifactId="spotbugs-annotations" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">4\.9\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
 


### PR DESCRIPTION
- pin spotbugs to pre-v4.9.0 as v4.9.0 requires Java11