### PR TITLE
Updates

### DIFF
--- a/src/main/java/co/luminositylabs/config/Configuration.java
+++ b/src/main/java/co/luminositylabs/config/Configuration.java
@@ -17,7 +17,6 @@
 package co.luminositylabs.config;
 
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +42,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  *
  * @author Phillip Ross
  */
-@SuppressFBWarnings({"PI_DO_NOT_REUSE_PUBLIC_IDENTIFIERS_CLASS_NAMES"})
 @ApplicationScoped
 public class Configuration implements Serializable {
 


### PR DESCRIPTION
- removed PI_DO_NOT_REUSE_PUBLIC_IDENTIFIERS_CLASS_NAMES suppression from Configuration class as it is no longer necessary