### PR TITLE
Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -36,6 +36,11 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <rule groupId="fish.payara.security.connectors" artifactId="openid-standalone" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
         <rule groupId="fish.payara.transformer" artifactId="fish.payara.transformer.payara" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency.arquillian.version>1.9.3.Final</dependency.arquillian.version>
         <dependency.arquillian-payara-containers.version>3.1</dependency.arquillian-payara-containers.version>
         <dependency.payara.version>6.2025.2</dependency.payara.version>
-        <dependency.shrinkwrap-resolver.version>3.3.3</dependency.shrinkwrap-resolver.version>
+        <dependency.shrinkwrap-resolver.version>3.3.4</dependency.shrinkwrap-resolver.version>
         <dependency.maven-shared-utils.version>3.4.2</dependency.maven-shared-utils.version>
     </properties>
 


### PR DESCRIPTION
- shrinkwrap-resolver updated from v3.3.3 to v3.3.4
- added fish.payara.security.connectors:openid-standalone ignore rule to maven-version-rules.xml