### PR TITLE
branch maintenance jakarta ee 9.1 Updates

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/luminositylabs-config.iml" filepath="$PROJECT_DIR$/luminositylabs-config.iml" />
-    </modules>
-  </component>
-</project>

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -101,6 +101,11 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <rule groupId="jakarta.mvc" artifactId="jakarta.mvc-api" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
         <rule groupId="jakarta.persistence" artifactId="jakarta.persistence-api" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
@@ -177,6 +182,16 @@
             </ignoreVersions>
         </rule>
         <rule groupId="org.eclipse.angus" artifactId="angus-mail" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="org.eclipse.krazo" artifactId="krazo-core" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="org.eclipse.krazo" artifactId="krazo-jersey" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.9.4.Final</dependency.arquillian.version>
         <dependency.arquillian-payara-containers.version>3.1</dependency.arquillian-payara-containers.version>
-        <dependency.payara.version>6.2025.4</dependency.payara.version>
+        <dependency.payara.version>6.2025.5</dependency.payara.version>
         <dependency.shrinkwrap-resolver.version>3.3.4</dependency.shrinkwrap-resolver.version>
         <dependency.maven-shared-utils.version>3.4.2</dependency.maven-shared-utils.version>
     </properties>


### PR DESCRIPTION
- payara updated from v6.2025.4 to v6.2025.5
- added jakata mvc and krazo ignore rules to maven-version-rules.xml


(cherry picked from commit cfae230dc52dfbd05eaf9a58ef0ff8a70e13fb1a)