### PR TITLE
Sonatype Central Portal Publishing

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -16,41 +16,15 @@
             </properties>
         </profile>
         <profile>
-            <id>sonatype-snapshots</id>
+            <id>sonatype-central-snapshots</id>
             <repositories>
                 <repository>
-                    <id>sonatype-snapshots</id>
+                    <id>sonatype-central-snapshots</id>
                     <snapshots>
                         <enabled>true</enabled>
                     </snapshots>
-                    <name>sonatype-snapshots</name>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-                </repository>
-            </repositories>
-        </profile>
-        <profile>
-            <id>sonatype-staging</id>
-            <repositories>
-                <repository>
-                    <id>sonatype-staging</id>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                    <name>sonatype-staging</name>
-                    <url>https://oss.sonatype.org/content/groups/staging/</url>
-                </repository>
-            </repositories>
-        </profile>
-        <profile>
-            <id>sonatype-releases</id>
-            <repositories>
-                <repository>
-                    <id>sonatype-releases</id>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                    <name>sonatype-releases</name>
-                    <url>https://oss.sonatype.org/content/groups/public/</url>
+                    <name>sonatype-central-snapshots</name>
+                    <url>https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/snapshots/</url>
                 </repository>
             </repositories>
         </profile>

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       MAVEN_PROPS: -Djavadoc.path=`which javadoc`
-      PROFILES: gpg,release-sign-artifacts,sonatype-deployment,sonatype-snapshots,sonatype-staging,sonatype-releases
+      PROFILES: gpg,release-sign-artifacts,sonatype-central-portal-deployment,sonatype-central-snapshots
       SETTINGS: .github/settings.xml
 
     steps:
@@ -85,8 +85,8 @@ jobs:
     - name: Maven deploy
       if: ${{ matrix.maven_deploy && (github.ref == 'refs/heads/main') && (github.event_name != 'pull_request') }}
       env:
-        OSSRHU: ${{ secrets.OSSRHU }}
-        OSSRHT: ${{ secrets.OSSRHT }}
+        SONATYPE_CENTRAL_PORTAL_REPO_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_REPO_USERNAME }}
+        SONATYPE_CENTRAL_PORTAL_REPO_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_REPO_PASSWORD }}
       run: ./mvnw -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} deploy
 
     - name: Docker maven build

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <scm>
         <url>https://github.com/luminositylabs/luminositylabs-config</url>
-        <connection>scm:git:https://github.com/luminositylabs/luminositylabs-config.git</connection>
+        <connection>scm:git:git@github.com:luminositylabs/luminositylabs-config.git</connection>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
- Updated SCM connection URL to use GitHub SSH in pom.xml
- Updated GHA settings.xml to replace ossrh server/profiles with sonatype-central-portal
- Updated GHA main.yml workflow to modify PROFILES env var to replace older OSSRH deployment profiles with newer Sonatype Central profiles
- Updated GHA main.yml workflow to modify env vars in deploy step to replace OSSRH env vars with Sonatype Central env vars