### PR TITLE
branch maintenance Jakarta ee 10  - Updates (#198)

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -166,6 +166,16 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <rule groupId="jakarta.xml.registry" artifactId="jakarta.xml.registry-api" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="jakarta.xml.rpc" artifactId="jakarta.xml.rpc-api" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
         <rule groupId="org.apache.santuario" artifactId="xmlsec" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.9.5.Final</dependency.arquillian.version>
         <dependency.arquillian-payara-containers.version>3.1</dependency.arquillian-payara-containers.version>
-        <dependency.payara.version>6.2025.5</dependency.payara.version>
+        <dependency.payara.version>6.2025.6</dependency.payara.version>
         <dependency.shrinkwrap-resolver.version>3.3.4</dependency.shrinkwrap-resolver.version>
         <dependency.maven-shared-utils.version>3.4.2</dependency.maven-shared-utils.version>
     </properties>


### PR DESCRIPTION
- maven updated from v3.9.9 to v3.9.10
- payara updated from v6.2025.5 to v6.2025.6
- added jakarta xml registry/rpc ignore rules to maven-version-rules.xml


(cherry picked from commit d3e34565a3fc149685183d810c4fb1964b2da9cd)