### PR TITLE
branch maintenance Jakarta ee 8 - Updates (#198)

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -225,6 +225,16 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <rule groupId="jakarta.xml.registry" artifactId="jakarta.xml.registry-api" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="jakarta.xml.rpc" artifactId="jakarta.xml.rpc-api" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
         <rule groupId="jakarta.xml.ws" artifactId="jakarta.xml.ws-api" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>


### PR DESCRIPTION
- maven updated from v3.9.9 to v3.9.10
- added jakarta xml registry/rpc ignore rules to maven-version-rules.xml



(cherry picked from commit d3e34565a3fc149685183d810c4fb1964b2da9cd)