### PR TITLE
branch maintenance Jakarta ee 10 - Updates

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -19,15 +19,17 @@
             <id>sonatype-central-snapshots</id>
             <repositories>
                 <repository>
-                    <id>sonatype-central-snapshots</id>
+                    <name>Central Portal Snapshots</name>
+                    <id>central-portal-snapshots</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
                     <snapshots>
                         <enabled>true</enabled>
                     </snapshots>
-                    <name>sonatype-central-snapshots</name>
-                    <url>https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/snapshots/</url>
                 </repository>
             </repositories>
         </profile>
     </profiles>
-
 </settings>

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -116,6 +116,11 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <rule groupId="jakarta.platform" artifactId="jakarta.jakartaee-api" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">.*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
         <rule groupId="jakarta.platform" artifactId="jakarta.jakartaee-web-api" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">.*</ignoreVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>co.luminositylabs.oss</groupId>
         <artifactId>luminositylabs-oss-parent</artifactId>
-        <version>0.3.3</version>
+        <version>0.3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>luminositylabs-config</artifactId>
@@ -66,6 +66,8 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- The arquillian-bom dependency imports slf4j-api and slfj-simple which may be defined with older
+                 versions and require overriding to get the latest versions. -->
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>


### PR DESCRIPTION
- luminositylabs-oss-parent updated from v0.3.3 to v0.3.4-SNAPSHOT
- added jakartaee-api ignore rule to maven-version-rules.xml
- Update snapshot repository settings in `settings.xml` to conform to central.sonatype.org documentation



(cherry picked from commit 25a36d741baeabae401e53df3b9cb723c3c81627)