### PR TITLE
branch maintenance Jakarta ee 10 - Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -306,5 +306,12 @@
                 <ignoreVersion type="regex">.*</ignoreVersion>
             </ignoreVersions>
         </rule>
+
+        <!-- Pin checkstyle version to pre-v11 (v11 requires Java11) -->
+        <rule groupId="com.puppycrawl.tools" artifactId="checkstyle" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">1[1-9]+\..*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
     </rules>
 </ruleset>


### PR DESCRIPTION
- modified checkstyle ignore rule in maven-version-rules.xml to ignore all versions 11 and above