### PR TITLE
branch maintenance Jakarta ee 9 1 - Checkstyle module migration (#311)

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -65,7 +65,7 @@
         <module name="JavadocMethod"/>
         <module name="JavadocType"/>
         <module name="JavadocVariable"/>
-        <module name="JavadocStyle"/>
+        <module name="SummaryJavadoc"/>
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See http://checkstyle.sf.net/config_naming.html -->


### PR DESCRIPTION
- migrated checkstyle.xml from using now-unsupported JavadocStyle module to SummaryJavadoc


(cherry picked from commit 6c70a70bdab552610d7177f6a6654ee3199290be)