### PR TITLE
branch maintenance Jakarta ee 10 - Updates (#316)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
   build-codebase:
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-26.04]
         jdk_version: [11.0.31-zulu, 17.0.19-zulu, 21.0.11-zulu]
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-26.04
             jdk_version: 11.0.31-zulu
             zulu_version: 11.88.17
             maven_deploy: true


### PR DESCRIPTION
- CI GHA runner os updated from ubuntu-24.04 to ubuntu-26.04


(cherry picked from commit 6f10c9ec963347f5182f4f566fb996cfaab65894)