### PR TITLE
branch maintenance Jakarta ee 8 - Updates (#316)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,11 @@ jobs:
   build-codebase:
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-26.04]
         jdk_version: [8.0.492-zulu, 11.0.31-zulu, 17.0.19-zulu]
         payara_server_embedded_profile_name: [payara-server-embedded, payara-server-embedded-no-jpms]
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-26.04
             jdk_version: 8.0.492-zulu
             zulu_version: 8.94.0.17
             maven_deploy: true


### PR DESCRIPTION
- CI GHA runner os updated from ubuntu-24.04 to ubuntu-26.04


(cherry picked from commit 6f10c9ec963347f5182f4f566fb996cfaab65894)